### PR TITLE
Send connection test errors to log file

### DIFF
--- a/mysqlfragfinder.sh
+++ b/mysqlfragfinder.sh
@@ -74,7 +74,7 @@ if [[ ! $mysqlPass ]]; then
 fi
 
 # Test connecting to the database:
-"${mysqlCmd}" -u"$mysqlUser" -p"$mysqlPass" -h"$mysqlHost" --skip-column-names --batch -e "show status" >/dev/null 2>&1
+"${mysqlCmd}" -u"$mysqlUser" -p"$mysqlPass" -h"$mysqlHost" --skip-column-names --batch -e "show status" >/dev/null 2>"$log"
 if [[ $? -gt 0 ]]; then
 	echo "An error occured, check $log for more information.";
 	exit 1;


### PR DESCRIPTION
If the connection test at line 77 fail you get a message that say to check the log file for more info but there is no file created because the errors are not directed to the file.

This small change fixes this problem.
