### PR TITLE
Portability fix

### DIFF
--- a/mysqlfragfinder.sh
+++ b/mysqlfragfinder.sh
@@ -49,11 +49,11 @@ fi
 if [[ ! $mysqlUser  && -f "$HOME/.my.cnf" ]]; then
 	if grep "user=" "$HOME/.my.cnf" >/dev/null 2>&1; then
 		if grep "password=" "$HOME/.my.cnf" >/dev/null 2>&1; then
-			mysqlUser=$(grep -m 1 "user=" "$HOME/.my.cnf" | sed -e 's/^[^=]\+=//g');
-			mysqlPass=$(grep -m 1 "password=" "$HOME/.my.cnf" | sed -e 's/^[^=]\+=//g');
+			mysqlUser=$(grep "user=" "$HOME/.my.cnf" | awk -F= 'NR==1{print $NF}');
+			mysqlPass=$(grep "password=" "$HOME/.my.cnf" | awk -F= 'NR==1{print $NF}');
 
 			if grep "host=" "$HOME/.my.cnf" >/dev/null 2>&1; then
-				mysqlHost=$(grep -m 1 "host=" "$HOME/.my.cnf" | sed -e 's/^[^=]\+=//g');
+				mysqlHost=$(grep "host=" "$HOME/.my.cnf" | awk -F= 'NR==1{print $NF}');
 			fi
 		else
 			echo "Found no pass line in your .my.cnf,, fix this or specify with --password"


### PR DESCRIPTION
`grep` does not support the `-m 1` parameter on all platforms.

Use `awk` instead to do both the parsing of the value after `=` and the selection of the first match.

Note, like the original code, this does not support `.my.cnf` files containing more than one user/pass.